### PR TITLE
fix: added noVerify Option HaaLeo/publish-vscode-extension#8

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,10 @@ inputs:
     description: 'Set this option to "true" to package your extension but do not publish it.'
     required: false
     default: false
+  noVerify:
+    description: 'Allow Extensions using proposed Api (enableProposedApi: true) publish to the Marketplace.'
+    required: false
+    default: false
 
 outputs:
   vsixPath:

--- a/src/createPackage.ts
+++ b/src/createPackage.ts
@@ -6,9 +6,9 @@ import * as path from 'path';
 import * as core from '@actions/core';
 
 import { createVSIX, ICreateVSIXOptions } from 'vsce';
-import { OVSXPublishOptions } from './types';
+import { ActionOptions } from './types';
 
-async function createPackage(ovsxOptions: OVSXPublishOptions): Promise<string> {
+async function createPackage(ovsxOptions: ActionOptions): Promise<string> {
     let vsixPath: string;
 
     if (ovsxOptions.extensionFile) {
@@ -26,7 +26,7 @@ async function createPackage(ovsxOptions: OVSXPublishOptions): Promise<string> {
     return vsixPath;
 }
 
-function _convertToVSCECreateVSIXOptions(options: OVSXPublishOptions, targetVSIXPath: string): ICreateVSIXOptions {
+function _convertToVSCECreateVSIXOptions(options: ActionOptions, targetVSIXPath: string): ICreateVSIXOptions {
     // Shallow copy of options
     const { baseContentUrl, baseImagesUrl, yarn: useYarn, packagePath: cwd } = { ...options };
     const result = { baseContentUrl, useYarn, baseImagesUrl, cwd, packagePath: targetVSIXPath };

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,8 @@ function _getInputs(): ActionOptions {
         // Set default value to undefined for not required inputs without default value
         extensionFile: core.getInput('extensionFile') || undefined,
         baseContentUrl: core.getInput('baseContentUrl') || undefined,
-        baseImagesUrl: core.getInput('baseImageUrl') || undefined
+        baseImagesUrl: core.getInput('baseImageUrl') || undefined,
+        noVerify: core.getInput('noVerify') === 'true',
     };
 }
 

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -2,9 +2,9 @@
 
 import { publish as ovsxPublish } from 'ovsx';
 import { publishVSIX as vscePublishVSIX, IPublishVSIXOptions as VSCEPublishOptions } from 'vsce';
-import { OVSXPublishOptions } from './types';
+import { ActionOptions } from './types';
 
-async function publish(ovsxOptions: OVSXPublishOptions): Promise<void> {
+async function publish(ovsxOptions: ActionOptions): Promise<void> {
     if (ovsxOptions.registryUrl === 'https://marketplace.visualstudio.com') {
         const vsceOptions = _convertToVSCEPublishOptions(ovsxOptions);
         await vscePublishVSIX(ovsxOptions.extensionFile, vsceOptions);
@@ -13,10 +13,16 @@ async function publish(ovsxOptions: OVSXPublishOptions): Promise<void> {
     }
 }
 
-function _convertToVSCEPublishOptions(options: OVSXPublishOptions): VSCEPublishOptions {
+function _convertToVSCEPublishOptions(options: ActionOptions): VSCEPublishOptions {
     // Shallow copy of options
-    const { baseContentUrl, baseImagesUrl, pat, yarn: useYarn } = { ...options };
-    const result = { baseContentUrl, useYarn, pat, baseImagesUrl };
+    const { baseContentUrl, baseImagesUrl, pat, yarn: useYarn, noVerify } = { ...options };
+    const result = {
+        baseContentUrl,
+        useYarn,
+        pat,
+        baseImagesUrl,
+        noVerify,
+    };
     return result;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,35 @@
-import { PublishOptions as OVSXPublishOptions } from 'ovsx';
-
-export interface ActionOptions extends OVSXPublishOptions {
+export interface ActionOptions {
+    /**
+    * The base URL of the registry API.
+    */
+    registryUrl?: string;
+    /**
+     * Personal access token.
+     */
+    pat?: string;
+    /**
+     * Path to the vsix file to be published. Cannot be used together with `packagePath`.
+     */
+    extensionFile?: string;
+    /**
+     * Path to the extension to be packaged and published. Cannot be used together
+     * with `extensionFile`.
+     */
+    packagePath?: string;
+    /**
+     * The base URL for links detected in Markdown files. Only valid with `packagePath`.
+     */
+    baseContentUrl?: string;
+    /**
+     * The base URL for images detected in Markdown files. Only valid with `packagePath`.
+     */
+    baseImagesUrl?: string;
+    /**
+     * Should use `yarn` instead of `npm`. Only valid with `packagePath`.
+     */
+    yarn?: boolean;
     dryRun: boolean;
+    noVerify?: boolean;
 }
 
 export interface PackageJSON {
@@ -12,5 +40,3 @@ export interface PackageJSON {
         url?: string;
     } | string;
 }
-
-export { OVSXPublishOptions };

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export interface ActionOptions {
      * Should use `yarn` instead of `npm`. Only valid with `packagePath`.
      */
     yarn?: boolean;
-    dryRun: boolean;
+    dryRun?: boolean;
     noVerify?: boolean;
 }
 

--- a/test/publish.test.ts
+++ b/test/publish.test.ts
@@ -31,14 +31,16 @@ describe('publish', () => {
             extensionFile: 'myExtensionFile',
             packagePath: 'myPackagePath',
             pat: 'myPersonalAccessToken',
-            yarn: false
+            yarn: false,
+            noVerify: true,
         });
 
         expect(publishVSIXStub).to.have.been.calledOnceWithExactly('myExtensionFile', {
             baseContentUrl: 'myBaseContentUrl',
             baseImagesUrl: 'myBaseImageUrl',
             pat: 'myPersonalAccessToken',
-            useYarn: false
+            useYarn: false,
+            noVerify: true,
         });
     });
 


### PR DESCRIPTION
noVerify is not explicitly set in public PublishOptions, but referenced in internal [IPublishOptions](https://github.com/microsoft/vscode-vsce/blob/main/src/publish.ts#L126)