### PR TITLE
Adds support for preRelease in vsce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+* Adds `--pre-release` functionality for `vsce` Issue [#16](https://github.com/HaaLeo/publish-vscode-extension/issues/16).
+
 [All Changes](https://github.com/HaaLeo/publish-vscode-extension/compare/v0.4.2...master)
 
 ## [v0.4.2](https://github.com/HaaLeo/publish-vscode-extension/tree/v0.4.2) 2021-06-26

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,10 @@ inputs:
     description: 'Allow publishing extensions to the visual studio marketplace which use a proposed API (enableProposedApi: true).'
     required: false
     default: false
+  preRelease:
+    description: 'Publish a version marked as a Pre-Release.'
+    required: false
+    default: false
 
 outputs:
   vsixPath:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@actions/core": "^1.4.0",
     "ovsx": "^0.2.0",
-    "vsce": "^1.95.0"
+    "vsce": "^2.5.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.19",

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ function _getInputs(): ActionOptions {
         baseContentUrl: core.getInput('baseContentUrl') || undefined,
         baseImagesUrl: core.getInput('baseImageUrl') || undefined,
         noVerify: core.getInput('noVerify') === 'true',
+        preRelease: core.getInput('preRelease') === 'true',
     };
 }
 

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -9,19 +9,23 @@ async function publish(ovsxOptions: ActionOptions): Promise<void> {
         const vsceOptions = _convertToVSCEPublishOptions(ovsxOptions);
         await vscePublishVSIX(ovsxOptions.extensionFile, vsceOptions);
     } else {
+        if (ovsxOptions.preRelease){
+            throw new Error('Open VSX does not support option preRelease');
+        }
         await ovsxPublish(ovsxOptions);
     }
 }
 
 function _convertToVSCEPublishOptions(options: ActionOptions): VSCEPublishOptions {
     // Shallow copy of options
-    const { baseContentUrl, baseImagesUrl, pat, yarn: useYarn, noVerify } = { ...options };
+    const { baseContentUrl, baseImagesUrl, pat, yarn: useYarn, noVerify, preRelease } = { ...options };
     const result = {
         baseContentUrl,
         useYarn,
         pat,
         baseImagesUrl,
         noVerify,
+        preRelease,
     };
     return result;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,11 +29,14 @@ export interface ActionOptions {
      */
     yarn?: boolean;
     dryRun?: boolean;
-
     /**
      * Use this flag to enable publishing extensions which use a proposed extension API.
      */
     noVerify?: boolean;
+    /**
+     * Mark this package as a pre-release, vsce argument `--pre-release`
+     */
+    preRelease?: boolean;
 }
 
 export interface PackageJSON {

--- a/test/publish.test.ts
+++ b/test/publish.test.ts
@@ -18,7 +18,7 @@ describe('publish', () => {
         publishOpenVSXStub = stub(ovsx, 'publish').resolves();
     });
 
-    beforeEach(()=>{
+    beforeEach(() => {
         publishOpenVSXStub.resetHistory();
         publishVSIXStub.resetHistory();
     });
@@ -33,6 +33,7 @@ describe('publish', () => {
             pat: 'myPersonalAccessToken',
             yarn: false,
             noVerify: true,
+            preRelease: true,
         });
 
         expect(publishVSIXStub).to.have.been.calledOnceWithExactly('myExtensionFile', {
@@ -41,6 +42,7 @@ describe('publish', () => {
             pat: 'myPersonalAccessToken',
             useYarn: false,
             noVerify: true,
+            preRelease: true,
         });
     });
 
@@ -65,4 +67,20 @@ describe('publish', () => {
             yarn: false
         });
     });
+
+    it('failed attempt to publish preRelease to Open VSX registry', async () =>
+        publish({
+            registryUrl: 'https://open-vsx.org',
+            baseContentUrl: 'myBaseContentUrl',
+            baseImagesUrl: 'myBaseImageUrl',
+            extensionFile: 'myExtensionFile',
+            packagePath: 'myPackagePath',
+            pat: 'myPersonalAccessToken',
+            yarn: true,
+            preRelease: true,
+        }).catch(error =>
+            expect(error)
+                .to.be.an('error')
+                .with.property('message', 'Open VSX does not support option preRelease')
+        ));
 });


### PR DESCRIPTION
Fixes Add pre-release support  #16

I suspect that a solution should look something like this.

A couple of notes:

1. I have not updated package-lock.json because I am on node v16 and the CI workflow is on v12. @HaaLeo if you could update the lockfile that would be great.
2. I was not sure if any of the files under dist/ are to be commit so I did not include any changes to index.js, etc.