### PR TITLE
Add dependencies parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ You can set any or all of the following input parameters:
 |`dryRun` |boolean |no | `false` | Set this option to `true` to package your extension but do not publish it. When using this option set the `pat` option to a stub value.
 |`noVerify` |boolean| no |`false` | Allow publishing extensions to the visual studio marketplace which use a proposed API (enableProposedApi: true). Similar to vsce's `--noVerify` command line argument.
 |`preRelease` |boolean| no |`false` | Mark the extensions release as pre-release. Currently only supported for the visual studio marketplace. Is only considered when packaging an extension.
+|`dependencies` |boolean| no |`true` | Check that dependencies defined in package.json exist in node_modules. Set to false if using yarn v2+ with pnp.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You can set any or all of the following input parameters:
 |`dryRun` |boolean |no | `false` | Set this option to `true` to package your extension but do not publish it. When using this option set the `pat` option to a stub value.
 |`noVerify` |boolean| no |`false` | Allow publishing extensions to the visual studio marketplace which use a proposed API (enableProposedApi: true). Similar to vsce's `--noVerify` command line argument.
 |`preRelease` |boolean| no |`false` | Mark the extensions release as pre-release. Currently only supported for the visual studio marketplace. Is only considered when packaging an extension.
-|`dependencies` |boolean| no |`true` | Check that dependencies defined in package.json exist in node_modules. Set to false if using yarn v2+ with pnp.
+|`dependencies` |boolean| no |`true` | Check that dependencies defined in `package.json` exist in `node_modules`. Set to `false` if using yarn berry with PnP.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,10 @@ inputs:
     description: 'Publish a version marked as a Pre-Release.'
     required: false
     default: false
+  dependencies:
+    description: 'Check that dependencies defined in package.json exist in node_modules. Set to false if using yarn v2+ with pnp.'
+    required: false
+    default: true    
 
 outputs:
   vsixPath:

--- a/src/createPackage.ts
+++ b/src/createPackage.ts
@@ -31,8 +31,8 @@ async function createPackage(ovsxOptions: ActionOptions): Promise<string> {
 
 function _convertToVSCECreateVSIXOptions(options: ActionOptions, targetVSIXPath: string): IPackageOptions {
     // Shallow copy of options
-    const { baseContentUrl, baseImagesUrl, yarn: useYarn, packagePath: cwd, preRelease } = { ...options };
-    const result: IPackageOptions = { baseContentUrl, useYarn, baseImagesUrl, cwd, packagePath: targetVSIXPath, preRelease };
+    const { baseContentUrl, baseImagesUrl, yarn: useYarn, packagePath: cwd, preRelease, dependencies } = { ...options };
+    const result: IPackageOptions = { baseContentUrl, useYarn, baseImagesUrl, cwd, packagePath: targetVSIXPath, preRelease, dependencies };
     return result;
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,6 @@ function _getInputs(): ActionOptions {
         baseImagesUrl: core.getInput('baseImageUrl') || undefined,
         noVerify: core.getInput('noVerify') === 'true',
         preRelease: core.getInput('preRelease') === 'true',
-        dependencies: core.getInput('dependencies') === 'true',
+        dependencies: core.getInput('dependencies') !== 'false',
     };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,5 +53,6 @@ function _getInputs(): ActionOptions {
         baseImagesUrl: core.getInput('baseImageUrl') || undefined,
         noVerify: core.getInput('noVerify') === 'true',
         preRelease: core.getInput('preRelease') === 'true',
+        dependencies: core.getInput('dependencies') === 'true',
     };
 }

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -17,7 +17,7 @@ async function publish(ovsxOptions: ActionOptions): Promise<void> {
 
 function _convertToVSCEPublishOptions(options: ActionOptions): VSCEPublishOptions {
     // Shallow copy of options
-    const { baseContentUrl, baseImagesUrl, pat, yarn: useYarn, noVerify, dependencies } = { ...options };    
+    const { baseContentUrl, baseImagesUrl, pat, yarn: useYarn, noVerify, dependencies } = { ...options };
     const result = {
         baseContentUrl,
         useYarn,

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -17,13 +17,14 @@ async function publish(ovsxOptions: ActionOptions): Promise<void> {
 
 function _convertToVSCEPublishOptions(options: ActionOptions): VSCEPublishOptions {
     // Shallow copy of options
-    const { baseContentUrl, baseImagesUrl, pat, yarn: useYarn, noVerify } = { ...options };
+    const { baseContentUrl, baseImagesUrl, pat, yarn: useYarn, noVerify, dependencies } = { ...options };    
     const result = {
         baseContentUrl,
         useYarn,
         pat,
         baseImagesUrl,
-        noVerify
+        noVerify,
+        dependencies,
     };
     return result;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,12 @@ export interface ActionOptions {
      * Mark this package as a pre-release, vsce argument `--pre-release`
      */
     preRelease?: boolean;
+    /**
+     * This is the inverse of the `--no-dependencies` flag in vsce. When false, vsce will
+     * not check for the existence of dependencies defined in package.json in node_modules.
+     * Set this to false if using yarn v2+ with PnP enabled.
+     */
+    dependencies?: boolean;
 }
 
 export interface PackageJSON {

--- a/test/createPackage.test.ts
+++ b/test/createPackage.test.ts
@@ -48,7 +48,8 @@ describe('createPackage', () => {
             packagePath: 'myPackagePath',
             pat: 'myPersonalAccessToken',
             yarn: false,
-            preRelease: true
+            preRelease: true,
+            dependencies: true,
         });
 
         expect(readFileStub).to.have.been.calledOnce;
@@ -59,7 +60,8 @@ describe('createPackage', () => {
             baseImagesUrl: 'myBaseImageUrl',
             useYarn: false,
             packagePath: path.normalize('myPackagePath/testName-testVersion.vsix'),
-            preRelease: true
+            preRelease: true,
+            dependencies: true,
         });
     });
 

--- a/test/publish.test.ts
+++ b/test/publish.test.ts
@@ -32,7 +32,8 @@ describe('publish', () => {
             packagePath: 'myPackagePath',
             pat: 'myPersonalAccessToken',
             yarn: false,
-            noVerify: true
+            noVerify: true,
+            dependencies: true,
         });
 
         expect(publishVSIXStub).to.have.been.calledOnceWithExactly('myExtensionFile', {
@@ -40,7 +41,8 @@ describe('publish', () => {
             baseImagesUrl: 'myBaseImageUrl',
             pat: 'myPersonalAccessToken',
             useYarn: false,
-            noVerify: true
+            noVerify: true,
+            dependencies: true,
         });
     });
 


### PR DESCRIPTION
# Summary

Enables the use of this github action for projects that use yarn2 or yarn3 (AKA [yarn berry](https://yarnpkg.com/getting-started/install)) with plug 'n' play. PnP does not use `node_modules`, so by passing `dependencies: false`,  VSCE will skip the node_modules check that is currently failing.

# Changes

Adds the `dependencies` parameter, similar to the one in VSCE.

# Related Issues

Fixes https://github.com/HaaLeo/publish-vscode-extension/issues/34