### PR TITLE
docs: add note about `depdencies: false` with pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You can set any or all of the following input parameters:
 |`dryRun` |boolean |no | `false` | Set this option to `true` to package your extension but do not publish it. When using this option set the `pat` option to a stub value.
 |`noVerify` |boolean| no |`false` | Allow publishing extensions to the visual studio marketplace which use a proposed API (enableProposedApi: true). Similar to vsce's `--noVerify` command line argument.
 |`preRelease` |boolean| no |`false` | Mark the extensions release as pre-release. Currently only supported for the visual studio marketplace. Is only considered when packaging an extension.
-|`dependencies` |boolean| no |`true` | Check that dependencies defined in `package.json` exist in `node_modules`. Set to `false` if using yarn berry with PnP.
+|`dependencies` |boolean| no |`true` | Check that dependencies defined in `package.json` exist in `node_modules`. Set to `false` if using pnpm or yarn v2+ with PnP.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ inputs:
     required: false
     default: false
   dependencies:
-    description: 'Check that dependencies defined in package.json exist in node_modules. Set to false if using yarn v2+ with pnp.'
+    description: 'Check that dependencies defined in package.json exist in node_modules. Set to false if using pnpm or yarn v2+ with pnp.'
     required: false
     default: true
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,7 @@ export interface ActionOptions {
     /**
      * This is the inverse of the `--no-dependencies` flag in vsce. When false, vsce will
      * not check for the existence of dependencies defined in package.json in node_modules.
-     * Set this to false if using yarn v2+ with PnP enabled.
+     * Set this to false if using pnpm or yarn v2+ with PnP enabled.
      */
     dependencies?: boolean;
 }


### PR DESCRIPTION
# Summary
Update docs about setting `dependencies: false` when using pnpm. The docs currently only mention the need to set this option for use with Yarn v2+.

# Changes
<!-- List detailed changes here as bullets -->
* Update docs about setting `dependencies: false` when using pnpm.

# Related Issues
<!-- Mention the issue this PR relates to. E.g.: Fixes #1 -->
Expands documentation made in #35
