### PR TITLE
Feat/target option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* Adds `--target` functionality for `vsce` and `osvx`. [#37](https://github.com/HaaLeo/publish-vscode-extension/issues/37).
+
 [All Changes](https://github.com/HaaLeo/publish-vscode-extension/compare/v1.4.0...master)
 
 ## [1.4.0](https://github.com/HaaLeo/publish-vscode-extension/tree/1.4.0) 2023-07-05

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ You can set any or all of the following input parameters:
 |`preRelease` |boolean| no |`false` | Mark the extensions release as pre-release. Is only considered when packaging an extension.
 |`dependencies` |boolean| no |`true` | Check that dependencies defined in `package.json` exist in `node_modules`. Set to `false` if using pnpm or yarn v2+ with PnP.
 |`skipDuplicate` |boolean| no |`false` | Fail silently if version already exists on the marketplace. Equivalent to the `--skip-duplicate` option of the vsce CLI.
+|`target` |string| no | - | Target architecture(s) the extension should run on
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ branding:
 inputs:
   # Required
   pat:
-    description: 'Personal access token'
+    description: 'Personal access token.'
     required: true
 
   # Optional
@@ -17,7 +17,7 @@ inputs:
     description: 'Path to the vsix file to be published. Cannot be used together with packagePath.'
     required: false
   registryUrl:
-    description: 'Use the registry API at this base URL'
+    description: 'Use the registry API at this base URL.'
     required: false
     default: 'https://open-vsx.org'
   packagePath:
@@ -51,11 +51,11 @@ inputs:
     required: false
     default: true
   skipDuplicate:
-    description: 'Fail silently if version already exists on the marketplace'
+    description: 'Fail silently if version already exists on the marketplace.'
     required: false
     default: false
   target:
-    description: 'Target architecture(s) the extension should run on'
+    description: 'Target architecture(s) the extension should run on.'
     required: false
     default: ''
 

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ inputs:
     required: false
     default: false
   target:
-    description: 'Target architecture'
+    description: 'Target architecture(s) the extension should run on'
     required: false
     default: ''
 

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,10 @@ inputs:
     description: 'Fail silently if version already exists on the marketplace'
     required: false
     default: false
+  target:
+    description: 'Target architecture'
+    required: false
+    default: ''
 
 outputs:
   vsixPath:

--- a/src/createPackage.ts
+++ b/src/createPackage.ts
@@ -18,7 +18,7 @@ async function createPackage(ovsxOptions: ActionOptions): Promise<string> {
     else if (ovsxOptions.packagePath) {
         const packageName = await _getPackageName(ovsxOptions.packagePath);
         vsixPath = path.join(ovsxOptions.packagePath, packageName);
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+
         const options = _convertToVSCECreateVSIXOptions(ovsxOptions, vsixPath);
         core.info('Start packaging the extension.');
         await createVSIX(options);
@@ -45,4 +45,5 @@ async function _getPackageName(packagePath: string): Promise<string> {
 
     return `${json.name}-${json.version}.vsix`;
 }
+
 export { createPackage };

--- a/src/createPackage.ts
+++ b/src/createPackage.ts
@@ -33,6 +33,7 @@ function _convertToVSCECreateVSIXOptions(options: ActionOptions, targetVSIXPath:
     // Shallow copy of options
     const { baseContentUrl, baseImagesUrl, yarn: useYarn, packagePath: cwd, preRelease, dependencies } = { ...options };
     const result: IPackageOptions = { baseContentUrl, useYarn, baseImagesUrl, cwd, packagePath: targetVSIXPath, preRelease, dependencies };
+
     return result;
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,5 +55,6 @@ function _getInputs(): ActionOptions {
         preRelease: core.getInput('preRelease') === 'true',
         dependencies: core.getInput('dependencies') === 'true',
         skipDuplicate: core.getInput('skipDuplicate') === 'true',
+        target: core.getInput('target') || undefined,
     };
 }

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -6,7 +6,6 @@ import { ActionOptions } from './types';
 
 async function publish(ovsxOptions: ActionOptions): Promise<void> {
     if (ovsxOptions.registryUrl === 'https://marketplace.visualstudio.com') {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const vsceOptions = _convertToVSCEPublishOptions(ovsxOptions);
         await vscePublishVSIX(ovsxOptions.extensionFile, vsceOptions);
     } else {

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -10,7 +10,15 @@ async function publish(ovsxOptions: ActionOptions): Promise<void> {
         const vsceOptions = _convertToVSCEPublishOptions(ovsxOptions);
         await vscePublishVSIX(ovsxOptions.extensionFile, vsceOptions);
     } else {
-        const options: PublishOptions = { ...ovsxOptions, packagePath: [ovsxOptions.packagePath] };
+        let options: PublishOptions;
+
+        if (ovsxOptions.target) {
+            const targets = ovsxOptions.target.split(ovsxOptions.target);
+            options = { ...ovsxOptions, targets, packagePath: [ovsxOptions.packagePath] };
+        } else {
+            options = { ...ovsxOptions, packagePath: [ovsxOptions.packagePath] };
+        }
+
         const results = await ovsxPublish(options);
         results?.forEach(result => {
             if (result.status === 'rejected') {
@@ -22,7 +30,7 @@ async function publish(ovsxOptions: ActionOptions): Promise<void> {
 
 function _convertToVSCEPublishOptions(options: ActionOptions): VSCEPublishOptions {
     // Shallow copy of options
-    const { baseContentUrl, baseImagesUrl, pat, yarn: useYarn, noVerify, dependencies, skipDuplicate, preRelease } = { ...options };
+    const { baseContentUrl, baseImagesUrl, pat, yarn: useYarn, noVerify, dependencies, skipDuplicate, preRelease, target } = { ...options };
     const result = {
         baseContentUrl,
         useYarn,
@@ -31,7 +39,8 @@ function _convertToVSCEPublishOptions(options: ActionOptions): VSCEPublishOption
         noVerify,
         dependencies,
         skipDuplicate,
-        preRelease
+        preRelease,
+        target
     };
     return result;
 }

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -12,7 +12,8 @@ async function publish(ovsxOptions: ActionOptions): Promise<void> {
         let options: PublishOptions;
 
         if (ovsxOptions.target) {
-            const targets = ovsxOptions.target.split(ovsxOptions.target);
+            const targets = ovsxOptions.target.split(' ');
+
             options = { ...ovsxOptions, targets, packagePath: [ovsxOptions.packagePath] };
         } else {
             options = { ...ovsxOptions, packagePath: [ovsxOptions.packagePath] };

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,14 @@ export interface ActionOptions {
      */
     skipDuplicate?: boolean;
 
+    /**
+     * Target architecture(s) the extension should run on.
+     * This string needs to be formatted like 'arch1 arch2 arch3' when targeting multiple architectures.
+     *
+     * See the following for the possible target values:
+     *
+     * https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions
+     */
     target?: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,8 @@ export interface ActionOptions {
      * Don't throw an error when the package version is already present in the registry
      */
     skipDuplicate?: boolean;
+
+    target?: string;
 }
 
 export interface PackageJSON {

--- a/test/publish.test.ts
+++ b/test/publish.test.ts
@@ -13,6 +13,7 @@ use(sinonChai);
 describe('publish', () => {
     let publishVSIXStub: SinonStub;
     let publishOpenVSXStub: SinonStub;
+
     before(() => {
         publishVSIXStub = stub(vsce, 'publishVSIX').resolves();
         publishOpenVSXStub = stub(ovsx, 'publish').resolves();
@@ -35,7 +36,8 @@ describe('publish', () => {
             noVerify: true,
             dependencies: true,
             skipDuplicate: false,
-            preRelease: false
+            preRelease: false,
+            target: 'win32-x64 linux-x64'
         });
 
         expect(publishVSIXStub).to.have.been.calledOnceWithExactly('myExtensionFile', {
@@ -46,7 +48,8 @@ describe('publish', () => {
             noVerify: true,
             dependencies: true,
             skipDuplicate: false,
-            preRelease: false
+            preRelease: false,
+            target: 'win32-x64 linux-x64'
         });
     });
 
@@ -58,7 +61,8 @@ describe('publish', () => {
             extensionFile: 'myExtensionFile',
             packagePath: 'myPackagePath',
             pat: 'myPersonalAccessToken',
-            yarn: false
+            yarn: false,
+            target: 'win32-x64 linux-x64'
         });
 
         expect(publishOpenVSXStub).to.have.been.calledOnceWithExactly({
@@ -68,7 +72,9 @@ describe('publish', () => {
             extensionFile: 'myExtensionFile',
             packagePath: ['myPackagePath'],
             pat: 'myPersonalAccessToken',
-            yarn: false
+            yarn: false,
+            targets: ['win32-x64', 'linux-x64'],
+            target: 'win32-x64 linux-x64'
         });
     });
 


### PR DESCRIPTION
# Summary
The option `target`, denoting the target architectures the extension can be used on, was added to the Action, since both `vsce` and `osvx` now support it.

# Changes
* optional `target` option added to the Action

# Related Issues
Implements #37
